### PR TITLE
12-byte IVs

### DIFF
--- a/src/fossil/stanzaio/omemo.js
+++ b/src/fossil/stanzaio/omemo.js
@@ -595,7 +595,7 @@ export class OmemoClient {
 
     await window.crypto.getRandomValues(randomSource);
     const gcmKey = randomSource.slice(0, 16);
-    const iv = randomSource.slice(16);
+    const iv = randomSource.slice(12);
 
     const subtleKey = await subtleCrypto.importKey("raw", gcmKey, {name: "AES-GCM"}, false, ['decrypt', 'encrypt']);
     const payload = new TextEncoder().encode(plaintext);


### PR DESCRIPTION
The XEP-0384 0.3.0 does not specify the "IV" value and the 0.3.1 version has been missing before the 0.4.0 version.
All OMEMO 0.3.0 clients must send with 12-byte instead 16-byte IV.